### PR TITLE
Add health checks for Kafka and Postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,12 @@ services:
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+    healthcheck:
+      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
     networks:
       - flink-network
 
@@ -51,6 +57,11 @@ services:
       - "5432:5432"
     volumes:
       - ./postgres/init.sql:/docker-entrypoint-initdb.d/init.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       - flink-network
 


### PR DESCRIPTION
## Summary
- add health checks for Kafka and Postgres so compose dependencies succeed

## Testing
- `docker-compose config`
- ⚠️ `dockerd --storage-driver=vfs --iptables=false` (failed: Error initializing network controller)


------
https://chatgpt.com/codex/tasks/task_e_689cb150968c83299715b2e936228b44